### PR TITLE
Update PFColorHash.swift

### DIFF
--- a/Class/PFColorHash.swift
+++ b/Class/PFColorHash.swift
@@ -25,7 +25,7 @@ open class PFColorHash {
             if (ret > maxSafeInt) {
                 ret = ret / seed2
             }
-            ret = ret * seed1 + element.unicodeScalarCodePoint()
+            ret = ret * seed1 + Int64(element.unicodeScalarCodePoint())
         }
         return ret
     }


### PR DESCRIPTION
Fixes error 
> '+' is unavailable: Please use explicit type conversions or Strideable methods for mixed-type arithmetics.