### PR TITLE
Swift Package Manager Support + some convenience

### DIFF
--- a/Class/PFColorHash.swift
+++ b/Class/PFColorHash.swift
@@ -6,7 +6,11 @@
 //  Copyright (c) 2015 Cee. All rights reserved.
 //
 
-import Foundation
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
 
 open class PFColorHash {
     
@@ -67,7 +71,18 @@ open class PFColorHash {
         
         return (Double(h), Double(s), Double(l))
     }
-
+    
+    #if os(macOS)
+    public func nsColor(_ str: String) -> NSColor {
+        let hsl = self.hsl(str)
+        return NSColor(hue: hsl.h, saturation: hsl.s, lightness: hsl.l, alpha: 1)
+    }
+    #else
+    public func uiColor(_ str: String) -> UIColor {
+        let hsl = self.hsl(str)
+        return UIColor(hue: hsl.h, saturation: hsl.s, lightness: hsl.l, alpha: 1)
+    }
+    #endif
     
     final public func rgb(_ str: String) -> (r: Int, g: Int, b: Int) {
         let hslValue = hsl(str)
@@ -122,4 +137,28 @@ extension Character
         
         return Int(scalars[scalars.startIndex].value)
     }
+}
+
+#if os(macOS)
+typealias SystemColor = NSColor
+#else
+typealias SystemColor = UIColor
+#endif
+
+extension SystemColor {
+
+    // https://gist.github.com/adamgraham/3ada1f7f4cdf8131dd3d2d95bd116cfc
+    convenience init(hue: CGFloat, saturation: CGFloat, lightness: CGFloat, alpha: CGFloat = 1.0) {
+
+        let h = hue / 360.0
+        var s = saturation
+        let l = lightness
+
+        let t = s * ((l < 0.5) ? l : (1.0 - l))
+        let b = l + t
+        s = (l > 0.0) ? (2.0 * t / b) : 0.0
+
+        self.init(hue: h, saturation: s, brightness: b, alpha: alpha)
+    }
+
 }

--- a/PFColorHash/ViewController.swift
+++ b/PFColorHash/ViewController.swift
@@ -60,10 +60,7 @@ extension ViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let index = states.count - (indexPath as NSIndexPath).row - 1
         let str = states[index]
-        let color = UIColor(red: (CGFloat)(colorHash.rgb(str).r) / 255.0,
-                          green: (CGFloat)(colorHash.rgb(str).g) / 255.0,
-                           blue: (CGFloat)(colorHash.rgb(str).b) / 255.0,
-                          alpha: 1.0)
+        let color = colorHash.uiColor(str)
         
         let cell: UITableViewCell = UITableViewCell(style: UITableViewCell.CellStyle.subtitle, reuseIdentifier: "cell")
         

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PFColorHash",
+    platforms: [
+        .iOS(.v13), .macOS(.v10_13), .watchOS(.v4), .tvOS(.v13)
+    ],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "PFColorHash",
+            targets: ["PFColorHash"]),
+        ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "PFColorHash",
+            dependencies: [],
+            path: "Class"),
+        ]
+)


### PR DESCRIPTION
This pull request includes 2 things:
1. Swift Package Manager support, for easier modern usages.
2. A direct `uiColor` & `nsColor` function to get a `UIColor` or `NSColor` directly from a PFColorHash object.
```Swift
let colorHash = PFColorHash()
let uiColor = colorHash.uiColor("this is a test string")
```
